### PR TITLE
Apply uber as the first argument instead of the last.

### DIFF
--- a/augment.js
+++ b/augment.js
@@ -9,9 +9,12 @@
     var slice = Array.prototype.slice;
 
     return function (base, body) {
-        var uber = Factory.prototype = typeof base === "function" ? base.prototype : base;
-        var prototype = new Factory;
-        body.apply(prototype, slice.call(arguments, 2).concat(uber));
+        var 
+        uber = Factory.prototype = typeof base === "function" ? base.prototype : base,
+        prototype = new Factory,
+        args = slice.call(arguments, 2);
+        args.unshift(uber);
+        body.apply(prototype, args);
         if (!prototype.hasOwnProperty("constructor")) return prototype;
         var constructor = prototype.constructor;
         constructor.prototype = prototype;


### PR DESCRIPTION
Apply uber as the first argument instead of the last.

Intuitively reference the parent/base class as in the following case:

``` js
var Parent = augment(Object, function() {

  this.constructor = function() {
    // stuff
  };

  this.method = function() {
  };
});

var Child = augment(Parent, function(parent, other, args) {

  this.constructor = function() {
    // more stuff
  };

  this.method = function() {
    parent.method();
  };
}, 'other', 'args');
```

---

Originally, I was going to PR the following code:

``` js
body.apply(prototype, [uber].concat(slice.call(arguments, 2)));
```

but I feel that `Array.prototype.unshift` is the way to go.
